### PR TITLE
Mocha test command option

### DIFF
--- a/.dokker.json
+++ b/.dokker.json
@@ -14,6 +14,7 @@
     "github": "https://github.com/oceanhouse21/dokker/blob/master/dokker.js"
   },
   "mocha": {
+    "command": "mocha --reporter doc",
     "test": "test/dokker.js",
     "path": "tests.html",
     "template": "templates/tests.ejs.html"

--- a/dokker.js
+++ b/dokker.js
@@ -121,7 +121,9 @@ Dokker.injectTemplate = function(options) {
 Dokker.createTests = function(options) {
   return new Promise(function(resolve, reject) {
     var template, tests;
-    exec('mocha --reporter doc', function(error, stdout) {
+    // allows specification of mocha.command in .dokker.json, e.g. 'mocha -u tdd --reporter doc'
+    var cmd = options.command || 'mocha --reporter doc';
+    exec(cmd, function(error, stdout) {
       if(error) return reject(error);
       tests = stdout;
       return read(options.template, 'utf8')
@@ -378,6 +380,8 @@ Dokker.configure = function(options) {
       data.jsdoc.template = (data.jsdoc.template) ? path.join(process.cwd(), data.jsdoc.template) : path.join(__dirname, 'templates/index.ejs.html');
       data.mocha.template = (data.mocha.template) ? path.join(process.cwd(), data.mocha.template) : path.join(__dirname, 'templates/tests.ejs.html');
       data.mocha.path = path.join(process.cwd(), data.dir, data.mocha.path);
+      // specifies mocha command in .dokker.json; e.g. mocha -u tdd -R spec
+      data.mocha.command = path.join(process.cwd(), data.dir, data.mocha.command);
       data.literate.dir = path.join(process.cwd(), data.dir, data.literate.dir);
       data.jsdoc.markdown = path.join(process.cwd(), data.dir, data.jsdoc.markdown);
       data.jsdoc.html = path.join(process.cwd(), data.dir, data.jsdoc.html);

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -23,10 +23,41 @@ body {
     min-height: 100%
 }
 code {
-    font-family: Consolas, Courier New, monospace
+    /*font-family: 'Roboto', 'Helvetica Neue', sans-serif;*/
+    font-family: 'Source Code Pro', Consolas, 'Courier New', monospace;
+    letter-spacing: 0.03em;
+}
+.lang-js {
+  color: #78dbf9;
+}
+span.hljs-number {
+  color: #d59cf6;
+}
+span.hljs-string{
+  color: #8bdb97;
+}
+span.hljs-regexp{
+  color: #dbad83;
+}
+span.hljs-literal{
+  color: #e26a78;
+}
+span.hljs-keyword{
+  color: #d59cf6;
+}
+span.hljs-comment {
+  color: #99a4c7;
+}
+span.hljs-special {
+  color: #bdc4df;
 }
 pre {
-    background: #000;
+    box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.137255);
+    box-shadow: 0px 0px 2px 1px rgba(0, 0, 0, 0.0980392);
+    box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.0823529);
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+    background: #2b303b;
     margin: 1em 0;
     padding: .5em 20px;
     overflow-x: scroll;
@@ -190,8 +221,14 @@ pre .sy0 {
 #docs a.alias {
     opacity: .5
 }
+#docs div div div div {
+    box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.137255);
+    box-shadow: 0px 0px 2px 1px rgba(0, 0, 0, 0.0980392);
+    box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.0823529);
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+}
 #docs div div div {
-    border: 1px solid #d3d3d3;
     border-top: 0;
     margin: 0 .5em 1em
 }
@@ -219,16 +256,15 @@ pre .sy0 {
     margin: .5em 0 0
 }
 #docs h3 {
-    background: #663819;
-    box-shadow: 0 .25em .5em #d3d3d3;
-    border-top: 1px solid #d3d3d3;
-    border-bottom: 1px solid #d3d3d3;
+    background: rgb(63, 107, 196);
+    border-radius: 3px 3px 0 0;
+    border: 1px solid rgba(75, 71, 71, 0.14);
     margin: .5em 0;
-    padding: .75em 0 .75em 10px;
+    padding: .8em 0 .8em 10px;
     position: relative
 }
 #docs h3>code {
-    color: #eee
+    color: #fbfbfb
 }
 #docs h3 a {
     position: absolute;
@@ -352,12 +388,6 @@ pre .sy0 {
     #docs .doc-container .first-heading {
         margin-top: 0
     }
-}
-span.hljs-string{
-  color:#FAFF02;
-}
-span.hljs-keyword{
-  color: #5AF700;
 }
 @media (-ms-high-contrast: active) and (max-width: 1280px),
 (-ms-high-contrast: none) and (max-width: 1280px) {


### PR DESCRIPTION
The fix for issue [#5](https://github.com/oceanhouse21/dokker/issues/5).
Now user can optionally specify which mocha test command to use, for example, `mocha -u tdd -R doc`.
