### PR TITLE
Added gulp+browserSync for #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,21 @@ Creating a documentation is really simple with the help of Dokker. You just conf
 
 **Live edit your documentation**
 
-If you want to work on your source file and see how the documentation evolves you can start ```./node_modules/dokker/bin/watch``` and a Node.js/Express server is started for you that serves your Dokker project at [localhost:9000](http://localhost:9000).
+If you want to work on your source file and see how the documentation evolves, you can do ```./node_modules/dokker/bin/watch``` and it will open a browser with live preview.
 
-If you want to use the live edit function please install the [LiveReload](http://livereload.com/) plugin for your browser. You can then even start a ```nodemon ./node_modules/bin/dokker``` and whenever you hit save the HTML site is reloading. But before you might need ```npm install -g nodemon```.
+<!-- Node.js/Express server is started for you that serves your Dokker project at [localhost:9000](http://localhost:9000).
+
+If you want to use the live edit function please install the [LiveReload](http://livereload.com/) plugin for your browser. You can then even start a ```nodemon ./node_modules/bin/dokker``` and whenever you hit save the HTML site is reloading. But before you might need ```npm install -g nodemon```. -->
 
 **Deploy to Github Pages**
 
 If you want to deploy your documentation to Github Pages, run ```./node_modules/dokker/bin/gh-pages```. Finally a separate branch, named ```gh-pages``` is created from the ```docs``` folder. That is enough for Github to serve your documentation. Please do not forget to ```git commit``` your changes before your run ```gh-pages``` command.
+
+## Dokker in the wild
+Some examples by our users. Let us know what you did with Dokker too!
+
+- [Dokker.js](http://dokkerjs.com)
+- [lomath](http://kengz.github.io/lomath/)
 
 ## Further Reading
 

--- a/dokker.js
+++ b/dokker.js
@@ -26,7 +26,7 @@ var Dokker = {};
  * @memberOf Dokker
  * @type string
  */
-Dokker.VERSION = '0.1.0';
+Dokker.VERSION = '0.1.2';
 
 /**
  * Creates a HTML file that transcludes the HTML snippet that was created

--- a/dokker.js
+++ b/dokker.js
@@ -30,7 +30,7 @@ Dokker.VERSION = '0.1.2';
 
 /**
  * Creates a HTML file that transcludes the HTML snippet that was created
- * by the docdown module into an ejs template which is defined by the 
+ * by the docdown module into an ejs template which is defined by the
  * .dokker.json configuration file.
  *
  * @static
@@ -63,40 +63,40 @@ Dokker.VERSION = '0.1.2';
 // created with docdown. Also tweak the HTML page a bit and finally
 // inject the README.md.
 Dokker.injectTemplate = function(options) {
-    return new Promise(function(resolve, reject) {
-        var template, body, html, readme, $;
-        return read(options.template, 'utf8')
-            .then(function(data) {
-                template = data;
-                return read(options.readme, 'utf8');
-            }).then(function(data) {
-                readme = marked(data);
-                $ = cheerio.load(readme);
-                $('h1').remove();
-                readme = $.html();
-                return read(options.html, 'utf8');
-            }).then(function(data) {
-                $ = cheerio.load(data);
-                return ejs.render(template, {
-                    apiToc: $('.toc-container').html(),
-                    readme: readme,
-                    apiDoc: $('.doc-container').html(),
-                    // correctly setting links to your github/pages
-                    page_url: options.site,
-                    title: options.title,
-                    github_url: options.github,
-                    // fixed reference to generated annotation
-                    // the 'literate' in .dokker.json shall not require a source since it's never used.
-                    annotated_path: 'annotated/' + options.source
-                });
-            }).then(function(data) {
-                return write(options.html, data, 'utf8');
-            }).then(function() {
-                resolve();
-            }).then(null, function(err) {
-                reject(err);
-            });
-    });
+  return new Promise(function(resolve, reject) {
+    var template, body, html, readme, $;
+    return read(options.template, 'utf8')
+      .then(function(data) {
+        template = data;
+        return read(options.readme, 'utf8');
+      }).then(function(data) {
+        readme = marked(data);
+        $ = cheerio.load(readme);
+        $('h1').remove();
+        readme = $.html();
+        return read(options.html, 'utf8');
+      }).then(function(data) {
+        $ = cheerio.load(data);
+        return ejs.render(template, {
+          apiToc: $('.toc-container').html(),
+          readme: readme,
+          apiDoc: $('.doc-container').html(),
+          // correctly setting links to your github/pages
+          page_url: options.site,
+          title: options.title,
+          github_url: options.github,
+          // fixed reference to generated annotation
+          // the 'literate' in .dokker.json shall not require a source since it's never used.
+          annotated_path: 'annotated/' + options.source
+        });
+      }).then(function(data) {
+        return write(options.html, data, 'utf8');
+      }).then(function() {
+        resolve();
+      }).then(null, function(err) {
+        reject(err);
+      });
+  });
 };
 
 /**
@@ -125,28 +125,28 @@ Dokker.injectTemplate = function(options) {
 // Create a HTML site from any mocha tests find when executing mocha
 // --reporter doc terminal command.
 Dokker.createTests = function(options) {
-    return new Promise(function(resolve, reject) {
-        var template, tests;
-        // allows specification of mocha.command in .dokker.json, e.g. 'mocha -u tdd --reporter doc'
-        var cmd = options.command || 'mocha --reporter doc';
-        exec(cmd, function(error, stdout) {
-            if (error) return reject(error);
-            tests = stdout;
-            return read(options.template, 'utf8')
-                .then(function(data) {
-                    template = data;
-                    return ejs.render(template, {
-                        tests: tests
-                    });
-                }).then(function(data) {
-                    return write(options.path, data, 'utf8');
-                }).then(function() {
-                    resolve();
-                }).then(null, function(err) {
-                    reject(err);
-                });
+  return new Promise(function(resolve, reject) {
+    var template, tests;
+    // allows specification of mocha.command in .dokker.json, e.g. 'mocha -u tdd --reporter doc'
+    var cmd = options.command || 'mocha --reporter doc';
+    exec(cmd, function(error, stdout) {
+      if (error) return reject(error);
+      tests = stdout;
+      return read(options.template, 'utf8')
+        .then(function(data) {
+          template = data;
+          return ejs.render(template, {
+            tests: tests
+          });
+        }).then(function(data) {
+          return write(options.path, data, 'utf8');
+        }).then(function() {
+          resolve();
+        }).then(null, function(err) {
+          reject(err);
         });
     });
+  });
 };
 
 /**
@@ -169,15 +169,15 @@ Dokker.createTests = function(options) {
 // Extract docs folder to separate git branch and finally push branch to
 // Github repository
 Dokker.ghPages = function() {
-    return new Promise(function(resolve, reject) {
-        exec('git subtree split -P docs -b gh-pages', function(error, stdout, stderr) {
-            if (error) return reject(stderr);
-            exec('git push origin gh-pages', function(error, stdout, stderr) {
-                if (error) return reject(stderr);
-                resolve();
-            });
-        });
+  return new Promise(function(resolve, reject) {
+    exec('git subtree split -P docs -b gh-pages', function(error, stdout, stderr) {
+      if (error) return reject(stderr);
+      exec('git push origin gh-pages', function(error, stdout, stderr) {
+        if (error) return reject(stderr);
+        resolve();
+      });
     });
+  });
 };
 
 /**
@@ -208,23 +208,23 @@ Dokker.ghPages = function() {
 // Create an HTML file from any source code comments in the style of
 // [literate programming](https://de.wikipedia.org/wiki/Literate_programming)
 Dokker.literate = function(options) {
-    return new Promise(function(resolve, reject) {
-        var tmpDir = path.join(process.cwd(), '/.tmp');
-        var tmpFile = path.join(tmpDir, options.source);
-        return read(path.join(process.cwd(), options.source), 'utf8')
-            .then(function(data) {
-                var source = data.replace(/^\s*(\*|\/\*).*[\r\n]/gm, '');
-                return Dokker.mkdir(tmpDir)
-                    .then(function() {
-                        return write(tmpFile, source, 'utf8');
-                    }).then(function() {
-                        docco.run(['', '', tmpFile, '-o', options.dir]);
-                        resolve();
-                    });
-            }).then(null, function(err) {
-                if (err) return reject(err);
-            });
-    });
+  return new Promise(function(resolve, reject) {
+    var tmpDir = path.join(process.cwd(), '/.tmp');
+    var tmpFile = path.join(tmpDir, options.source);
+    return read(path.join(process.cwd(), options.source), 'utf8')
+      .then(function(data) {
+        var source = data.replace(/^\s*(\*|\/\*).*[\r\n]/gm, '');
+        return Dokker.mkdir(tmpDir)
+          .then(function() {
+            return write(tmpFile, source, 'utf8');
+          }).then(function() {
+            docco.run(['', '', tmpFile, '-o', options.dir]);
+            resolve();
+          });
+      }).then(null, function(err) {
+        if (err) return reject(err);
+      });
+  });
 };
 
 /**
@@ -254,33 +254,33 @@ Dokker.literate = function(options) {
  */
 // Convert markdown from any source code comments with docdown module.
 Dokker.jsdocMarkdown = function(options) {
-    return new Promise(function(resolve, reject) {
-        var source, tmpFile, tmpDir;
-        return read(path.join(process.cwd(), options.source), 'utf8')
-            .then(function(data) {
-                source = data.replace(/^\s*(\/\/).*[\r\n]/gm, '');
-                tmpDir = path.join(process.cwd(), '/.tmp');
-                return Dokker.mkdir(tmpDir);
-            }).then(function() {
-                tmpFile = path.join(tmpDir, options.source);
-                return write(tmpFile, source, 'utf8');
-            }).then(function() {
-                var markdown = docdown({
-                    'path': tmpFile,
-                    'url': options.github,
-                    'toc': 'categories'
-                });
-                return write(options.markdown, markdown, 'utf8');
-            }).then(function() {
-                resolve();
-            }).then(null, function(err) {
-                reject(err);
-            });
-    });
+  return new Promise(function(resolve, reject) {
+    var source, tmpFile, tmpDir;
+    return read(path.join(process.cwd(), options.source), 'utf8')
+      .then(function(data) {
+        source = data.replace(/^\s*(\/\/).*[\r\n]/gm, '');
+        tmpDir = path.join(process.cwd(), '/.tmp');
+        return Dokker.mkdir(tmpDir);
+      }).then(function() {
+        tmpFile = path.join(tmpDir, options.source);
+        return write(tmpFile, source, 'utf8');
+      }).then(function() {
+        var markdown = docdown({
+          'path': tmpFile,
+          'url': options.github,
+          'toc': 'categories'
+        });
+        return write(options.markdown, markdown, 'utf8');
+      }).then(function() {
+        resolve();
+      }).then(null, function(err) {
+        reject(err);
+      });
+  });
 };
 
 /**
- * Create an HTML file from the Markdown file that was create with 
+ * Create an HTML file from the Markdown file that was create with
  * [Dokker.jsdocMarkdown()](#Dokker-jsdocMarkdown)
  *
  * @static
@@ -304,33 +304,33 @@ Dokker.jsdocMarkdown = function(options) {
 // Create an HTML file from any source code comments in the style of
 // [literate programming](https://de.wikipedia.org/wiki/Literate_programming)
 Dokker.jsdocHtml = function(options) {
-    return new Promise(function(resolve, reject) {
-        return read(options.markdown, 'utf8')
-            .then(function(data) {
-                var html = marked(data).replace(/<!-- /g, '<').replace(/ -->/g, '>');
-                return write(options.html, html, 'utf8');
-            }).then(function() {
-                resolve();
-            }).then(null, function(err) {
-                reject(err);
-            });
-    });
+  return new Promise(function(resolve, reject) {
+    return read(options.markdown, 'utf8')
+      .then(function(data) {
+        var html = marked(data).replace(/<!-- /g, '<').replace(/ -->/g, '>');
+        return write(options.html, html, 'utf8');
+      }).then(function() {
+        resolve();
+      }).then(null, function(err) {
+        reject(err);
+      });
+  });
 };
 
 // Internal helper function that creates any directory if not existing.
 Dokker.mkdir = function(dir) {
-    return new Promise(function(resolve, reject) {
-        fs.exists(dir, function(exists) {
-            if (exists) {
-                resolve();
-            } else {
-                fs.mkdir(dir, function(err) {
-                    if (err) return reject(err);
-                    resolve();
-                });
-            }
+  return new Promise(function(resolve, reject) {
+    fs.exists(dir, function(exists) {
+      if (exists) {
+        resolve();
+      } else {
+        fs.mkdir(dir, function(err) {
+          if (err) return reject(err);
+          resolve();
         });
+      }
     });
+  });
 };
 
 /**
@@ -380,25 +380,25 @@ Dokker.mkdir = function(dir) {
  */
 // Parses the options file, .Dokker.json, and sets the default parameters.
 Dokker.configure = function(options) {
-    return new Promise(function(resolve, reject) {
-        var file = path.join(process.cwd(), '.dokker.json');
-        return read(file, 'utf8')
-            .then(function(data) {
-                data = JSON.parse(data);
-                data.jsdoc.template = (data.jsdoc.template) ? path.join(process.cwd(), data.jsdoc.template) : path.join(__dirname, 'templates/index.ejs.html');
-                data.mocha.template = (data.mocha.template) ? path.join(process.cwd(), data.mocha.template) : path.join(__dirname, 'templates/tests.ejs.html');
-                data.mocha.path = path.join(process.cwd(), data.dir, data.mocha.path);
-                // specifies mocha command in .dokker.json; e.g. mocha -u tdd -R spec
-                // data.mocha.command = path.join(process.cwd(), data.dir, data.mocha.command);
-                data.literate.dir = path.join(process.cwd(), data.dir, data.literate.dir);
-                data.jsdoc.markdown = path.join(process.cwd(), data.dir, data.jsdoc.markdown);
-                data.jsdoc.html = path.join(process.cwd(), data.dir, data.jsdoc.html);
-                data.jsdoc.readme = path.join(process.cwd(), data.jsdoc.readme);
-                resolve(data);
-            }).then(null, function(err) {
-                reject(err);
-            });
-    });
+  return new Promise(function(resolve, reject) {
+    var file = path.join(process.cwd(), '.dokker.json');
+    return read(file, 'utf8')
+      .then(function(data) {
+        data = JSON.parse(data);
+        data.jsdoc.template = (data.jsdoc.template) ? path.join(process.cwd(), data.jsdoc.template) : path.join(__dirname, 'templates/index.ejs.html');
+        data.mocha.template = (data.mocha.template) ? path.join(process.cwd(), data.mocha.template) : path.join(__dirname, 'templates/tests.ejs.html');
+        data.mocha.path = path.join(process.cwd(), data.dir, data.mocha.path);
+        // specifies mocha command in .dokker.json; e.g. mocha -u tdd -R spec
+        // data.mocha.command = path.join(process.cwd(), data.dir, data.mocha.command);
+        data.literate.dir = path.join(process.cwd(), data.dir, data.literate.dir);
+        data.jsdoc.markdown = path.join(process.cwd(), data.dir, data.jsdoc.markdown);
+        data.jsdoc.html = path.join(process.cwd(), data.dir, data.jsdoc.html);
+        data.jsdoc.readme = path.join(process.cwd(), data.jsdoc.readme);
+        resolve(data);
+      }).then(null, function(err) {
+        reject(err);
+      });
+  });
 };
 
 /**
@@ -425,22 +425,22 @@ Dokker.configure = function(options) {
  */
 // Copy starter template to bootstrap any Dokker project.
 Dokker.copyTemplate = function(options) {
-    return new Promise(function(resolve, reject) {
-        var templatesDir = path.join(process.cwd(), 'templates');
-        return Dokker.mkdir(templatesDir)
-            .then(function() {
-                var oldStyle = path.join(__dirname, 'templates', 'styles.css');
-                var newStyle = path.join(process.cwd(), options.dir, 'styles.css');
-                fs.createReadStream(oldStyle).pipe(fs.createWriteStream(newStyle));
-                var oldLogo = path.join(__dirname, 'templates', 'logo.png');
-                var newLogo = path.join(process.cwd(), options.dir, 'logo.png');
-                fs.createReadStream(oldLogo).pipe(fs.createWriteStream(newLogo));
-                var oldApp = path.join(__dirname, 'templates', 'app.js');
-                var newApp = path.join(process.cwd(), options.dir, 'app.js');
-                fs.createReadStream(oldApp).pipe(fs.createWriteStream(newApp));
-                resolve();
-            });
-    });
+  return new Promise(function(resolve, reject) {
+    var templatesDir = path.join(process.cwd(), 'templates');
+    return Dokker.mkdir(templatesDir)
+      .then(function() {
+        var oldStyle = path.join(__dirname, 'templates', 'styles.css');
+        var newStyle = path.join(process.cwd(), options.dir, 'styles.css');
+        fs.createReadStream(oldStyle).pipe(fs.createWriteStream(newStyle));
+        var oldLogo = path.join(__dirname, 'templates', 'logo.png');
+        var newLogo = path.join(process.cwd(), options.dir, 'logo.png');
+        fs.createReadStream(oldLogo).pipe(fs.createWriteStream(newLogo));
+        var oldApp = path.join(__dirname, 'templates', 'app.js');
+        var newApp = path.join(process.cwd(), options.dir, 'app.js');
+        fs.createReadStream(oldApp).pipe(fs.createWriteStream(newApp));
+        resolve();
+      });
+  });
 };
 
 /**
@@ -460,12 +460,12 @@ Dokker.copyTemplate = function(options) {
  */
 // Copies the .Dokker.json file to bootstrap any Dokker project.
 Dokker.init = function() {
-    return new Promise(function(resolve, reject) {
-        var oldDok = path.join(__dirname, '.dokker.json');
-        var newDok = path.join(process.cwd(), '.dokker.json');
-        fs.createReadStream(oldDok).pipe(fs.createWriteStream(newDok));
-        resolve();
-    });
+  return new Promise(function(resolve, reject) {
+    var oldDok = path.join(__dirname, '.dokker.json');
+    var newDok = path.join(process.cwd(), '.dokker.json');
+    fs.createReadStream(oldDok).pipe(fs.createWriteStream(newDok));
+    resolve();
+  });
 };
 
 /**
@@ -487,14 +487,14 @@ Dokker.init = function() {
 // Starts the Node.js/Express server to watch Dokker.js project
 // documentation.
 Dokker.watch = function(options) {
-    // replacing watch cmd with gulp exported from gulpfile
-    var gulpex = require(__dirname + '/gulpfile.js').gulpex;
-    return gulpex();
-    // return new Promise(function(resolve, reject){ 
-    //   exec('DIR='+ options.dir + ' node ' + options.dir + '/app.js', function(error, stdout, stderr){
-    //     if(error) return reject(stderr);
-    //   });
-    // });
+  // replacing watch cmd with gulp exported from gulpfile
+  var gulpex = require(__dirname + '/gulpfile.js').gulpex;
+  return gulpex();
+  // return new Promise(function(resolve, reject){
+  //   exec('DIR='+ options.dir + ' node ' + options.dir + '/app.js', function(error, stdout, stderr){
+  //     if(error) return reject(stderr);
+  //   });
+  // });
 };
 
 module.exports = Dokker;

--- a/dokker.js
+++ b/dokker.js
@@ -26,7 +26,7 @@ var Dokker = {};
  * @memberOf Dokker
  * @type string
  */
- Dokker.VERSION = '0.1.0';
+Dokker.VERSION = '0.1.2';
 
 /**
  * Creates a HTML file that transcludes the HTML snippet that was created
@@ -58,45 +58,45 @@ var Dokker = {};
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Transclude in a ejs template file the HTML snippet that was ultimately
 // created with docdown. Also tweak the HTML page a bit and finally
 // inject the README.md.
 Dokker.injectTemplate = function(options) {
-  return new Promise(function(resolve, reject) {
-    var template, body, html, readme, $;
-    return read(options.template, 'utf8')
-    .then(function(data) {
-      template = data;
-      return read(options.readme, 'utf8');
-    }).then(function(data) {
-      readme = marked(data);
-      $ = cheerio.load(readme);
-      $('h1').remove();
-      readme = $.html();
-      return read(options.html, 'utf8');
-    }).then(function(data) {
-      $ = cheerio.load(data);
-      return ejs.render(template, {
-        apiToc: $('.toc-container').html(),
-        readme: readme,
-        apiDoc: $('.doc-container').html(),
-        // correctly setting links to your github/pages
-        page_url: options.site,
-        title: options.title,
-        github_url: options.github,
-        // fixed reference to generated annotation
-        // the 'literate' in .dokker.json shall not require a source since it's never used.
-        annotated_path: 'annotated/'+options.source
-      });
-    }).then(function(data) {
-      return write(options.html, data, 'utf8');
-    }).then(function() {
-      resolve();
-    }).then(null, function(err) {
-      reject(err);
+    return new Promise(function(resolve, reject) {
+        var template, body, html, readme, $;
+        return read(options.template, 'utf8')
+            .then(function(data) {
+                template = data;
+                return read(options.readme, 'utf8');
+            }).then(function(data) {
+                readme = marked(data);
+                $ = cheerio.load(readme);
+                $('h1').remove();
+                readme = $.html();
+                return read(options.html, 'utf8');
+            }).then(function(data) {
+                $ = cheerio.load(data);
+                return ejs.render(template, {
+                    apiToc: $('.toc-container').html(),
+                    readme: readme,
+                    apiDoc: $('.doc-container').html(),
+                    // correctly setting links to your github/pages
+                    page_url: options.site,
+                    title: options.title,
+                    github_url: options.github,
+                    // fixed reference to generated annotation
+                    // the 'literate' in .dokker.json shall not require a source since it's never used.
+                    annotated_path: 'annotated/' + options.source
+                });
+            }).then(function(data) {
+                return write(options.html, data, 'utf8');
+            }).then(function() {
+                resolve();
+            }).then(null, function(err) {
+                reject(err);
+            });
     });
-  });
 };
 
 /**
@@ -121,30 +121,32 @@ Dokker.injectTemplate = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Create a HTML site from any mocha tests find when executing mocha
 // --reporter doc terminal command.
 Dokker.createTests = function(options) {
-  return new Promise(function(resolve, reject) {
-    var template, tests;
-    // allows specification of mocha.command in .dokker.json, e.g. 'mocha -u tdd --reporter doc'
-    var cmd = options.command || 'mocha --reporter doc';
-    exec(cmd, function(error, stdout) {
-      if(error) return reject(error);
-      tests = stdout;
-      return read(options.template, 'utf8')
-      .then(function(data) {
-        template = data;
-        return ejs.render(template, {tests: tests});
-      }).then(function(data) {
-        return write(options.path, data, 'utf8');
-      }).then(function() {
-        resolve();
-      }).then(null, function(err) {
-        reject(err);
-      });
+    return new Promise(function(resolve, reject) {
+        var template, tests;
+        // allows specification of mocha.command in .dokker.json, e.g. 'mocha -u tdd --reporter doc'
+        var cmd = options.command || 'mocha --reporter doc';
+        exec(cmd, function(error, stdout) {
+            if (error) return reject(error);
+            tests = stdout;
+            return read(options.template, 'utf8')
+                .then(function(data) {
+                    template = data;
+                    return ejs.render(template, {
+                        tests: tests
+                    });
+                }).then(function(data) {
+                    return write(options.path, data, 'utf8');
+                }).then(function() {
+                    resolve();
+                }).then(null, function(err) {
+                    reject(err);
+                });
+        });
     });
-  });
 };
 
 /**
@@ -163,19 +165,19 @@ Dokker.createTests = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Extract docs folder to separate git branch and finally push branch to
 // Github repository
-Dokker.ghPages = function(){
-  return new Promise(function(resolve, reject) {
-    exec('git subtree split -P docs -b gh-pages', function(error, stdout, stderr) {
-      if(error) return reject(stderr);
-      exec('git push origin gh-pages', function(error, stdout, stderr) {
-        if(error) return reject(stderr);
-        resolve();
-      });
+Dokker.ghPages = function() {
+    return new Promise(function(resolve, reject) {
+        exec('git subtree split -P docs -b gh-pages', function(error, stdout, stderr) {
+            if (error) return reject(stderr);
+            exec('git push origin gh-pages', function(error, stdout, stderr) {
+                if (error) return reject(stderr);
+                resolve();
+            });
+        });
     });
-  });
 };
 
 /**
@@ -202,27 +204,27 @@ Dokker.ghPages = function(){
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Create an HTML file from any source code comments in the style of
 // [literate programming](https://de.wikipedia.org/wiki/Literate_programming)
-Dokker.literate = function (options) {
-  return new Promise(function(resolve, reject) {
-    var tmpDir = path.join(process.cwd(), '/.tmp');
-    var tmpFile = path.join(tmpDir, options.source);
-    return read(path.join(process.cwd(), options.source), 'utf8')
-    .then(function(data) {
-      var source = data.replace(/^\s*(\*|\/\*).*[\r\n]/gm, '');
-      return Dokker.mkdir(tmpDir)
-      .then(function() {
-        return write(tmpFile, source, 'utf8');
-      }).then(function(){
-        docco.run(['', '', tmpFile, '-o', options.dir]);
-        resolve();
-      });
-    }).then(null, function(err) {
-      if (err) return reject(err);
+Dokker.literate = function(options) {
+    return new Promise(function(resolve, reject) {
+        var tmpDir = path.join(process.cwd(), '/.tmp');
+        var tmpFile = path.join(tmpDir, options.source);
+        return read(path.join(process.cwd(), options.source), 'utf8')
+            .then(function(data) {
+                var source = data.replace(/^\s*(\*|\/\*).*[\r\n]/gm, '');
+                return Dokker.mkdir(tmpDir)
+                    .then(function() {
+                        return write(tmpFile, source, 'utf8');
+                    }).then(function() {
+                        docco.run(['', '', tmpFile, '-o', options.dir]);
+                        resolve();
+                    });
+            }).then(null, function(err) {
+                if (err) return reject(err);
+            });
     });
-  });
 };
 
 /**
@@ -249,32 +251,32 @@ Dokker.literate = function (options) {
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Convert markdown from any source code comments with docdown module.
-Dokker.jsdocMarkdown = function (options) {
-  return new Promise(function(resolve, reject) {
-    var source, tmpFile, tmpDir;
-    return read(path.join(process.cwd(), options.source), 'utf8')
-    .then(function(data){
-      source = data.replace(/^\s*(\/\/).*[\r\n]/gm, '');
-      tmpDir = path.join(process.cwd(), '/.tmp');
-      return Dokker.mkdir(tmpDir);
-    }).then(function(){
-      tmpFile = path.join(tmpDir, options.source);
-      return write(tmpFile, source, 'utf8');
-    }).then(function(){
-      var markdown = docdown({
-        'path': tmpFile,
-        'url': options.github,
-        'toc': 'categories'
-      });
-      return write(options.markdown, markdown, 'utf8');
-    }).then(function() {
-      resolve();
-    }).then(null, function(err) {
-      reject(err);
+Dokker.jsdocMarkdown = function(options) {
+    return new Promise(function(resolve, reject) {
+        var source, tmpFile, tmpDir;
+        return read(path.join(process.cwd(), options.source), 'utf8')
+            .then(function(data) {
+                source = data.replace(/^\s*(\/\/).*[\r\n]/gm, '');
+                tmpDir = path.join(process.cwd(), '/.tmp');
+                return Dokker.mkdir(tmpDir);
+            }).then(function() {
+                tmpFile = path.join(tmpDir, options.source);
+                return write(tmpFile, source, 'utf8');
+            }).then(function() {
+                var markdown = docdown({
+                    'path': tmpFile,
+                    'url': options.github,
+                    'toc': 'categories'
+                });
+                return write(options.markdown, markdown, 'utf8');
+            }).then(function() {
+                resolve();
+            }).then(null, function(err) {
+                reject(err);
+            });
     });
-  });
 };
 
 /**
@@ -298,37 +300,37 @@ Dokker.jsdocMarkdown = function (options) {
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Create an HTML file from any source code comments in the style of
 // [literate programming](https://de.wikipedia.org/wiki/Literate_programming)
-Dokker.jsdocHtml = function (options) {
-  return new Promise(function(resolve, reject) {
-    return read(options.markdown, 'utf8')
-    .then(function(data) {
-      var html = marked(data).replace(/<!-- /g,'<').replace(/ -->/g,'>');
-      return write(options.html, html, 'utf8');
-    }).then(function() {
-      resolve();
-    }).then(null, function(err) {
-      reject(err);
+Dokker.jsdocHtml = function(options) {
+    return new Promise(function(resolve, reject) {
+        return read(options.markdown, 'utf8')
+            .then(function(data) {
+                var html = marked(data).replace(/<!-- /g, '<').replace(/ -->/g, '>');
+                return write(options.html, html, 'utf8');
+            }).then(function() {
+                resolve();
+            }).then(null, function(err) {
+                reject(err);
+            });
     });
-  });
 };
 
 // Internal helper function that creates any directory if not existing.
 Dokker.mkdir = function(dir) {
-  return new Promise(function(resolve, reject) {
-    fs.exists(dir, function(exists) {
-      if (exists) {
-        resolve();
-      } else {
-        fs.mkdir(dir, function(err) {
-          if (err) return reject(err);
-          resolve();
+    return new Promise(function(resolve, reject) {
+        fs.exists(dir, function(exists) {
+            if (exists) {
+                resolve();
+            } else {
+                fs.mkdir(dir, function(err) {
+                    if (err) return reject(err);
+                    resolve();
+                });
+            }
         });
-      }
     });
-  });
 };
 
 /**
@@ -375,28 +377,28 @@ Dokker.mkdir = function(dir) {
  *   // => object with absolute pathes to the directory from
  *   // which the command was executed
  * });
-*/
+ */
 // Parses the options file, .Dokker.json, and sets the default parameters.
 Dokker.configure = function(options) {
-  return new Promise(function(resolve, reject){
-    var file = path.join(process.cwd(), '.dokker.json');
-    return read(file, 'utf8')
-    .then(function(data) {
-      data = JSON.parse(data);
-      data.jsdoc.template = (data.jsdoc.template) ? path.join(process.cwd(), data.jsdoc.template) : path.join(__dirname, 'templates/index.ejs.html');
-      data.mocha.template = (data.mocha.template) ? path.join(process.cwd(), data.mocha.template) : path.join(__dirname, 'templates/tests.ejs.html');
-      data.mocha.path = path.join(process.cwd(), data.dir, data.mocha.path);
-      // specifies mocha command in .dokker.json; e.g. mocha -u tdd -R spec
-      // data.mocha.command = path.join(process.cwd(), data.dir, data.mocha.command);
-      data.literate.dir = path.join(process.cwd(), data.dir, data.literate.dir);
-      data.jsdoc.markdown = path.join(process.cwd(), data.dir, data.jsdoc.markdown);
-      data.jsdoc.html = path.join(process.cwd(), data.dir, data.jsdoc.html);
-      data.jsdoc.readme = path.join(process.cwd(), data.jsdoc.readme);
-      resolve(data);
-    }).then(null, function(err) {
-      reject(err);
+    return new Promise(function(resolve, reject) {
+        var file = path.join(process.cwd(), '.dokker.json');
+        return read(file, 'utf8')
+            .then(function(data) {
+                data = JSON.parse(data);
+                data.jsdoc.template = (data.jsdoc.template) ? path.join(process.cwd(), data.jsdoc.template) : path.join(__dirname, 'templates/index.ejs.html');
+                data.mocha.template = (data.mocha.template) ? path.join(process.cwd(), data.mocha.template) : path.join(__dirname, 'templates/tests.ejs.html');
+                data.mocha.path = path.join(process.cwd(), data.dir, data.mocha.path);
+                // specifies mocha command in .dokker.json; e.g. mocha -u tdd -R spec
+                // data.mocha.command = path.join(process.cwd(), data.dir, data.mocha.command);
+                data.literate.dir = path.join(process.cwd(), data.dir, data.literate.dir);
+                data.jsdoc.markdown = path.join(process.cwd(), data.dir, data.jsdoc.markdown);
+                data.jsdoc.html = path.join(process.cwd(), data.dir, data.jsdoc.html);
+                data.jsdoc.readme = path.join(process.cwd(), data.jsdoc.readme);
+                resolve(data);
+            }).then(null, function(err) {
+                reject(err);
+            });
     });
-  });
 };
 
 /**
@@ -420,25 +422,25 @@ Dokker.configure = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Copy starter template to bootstrap any Dokker project.
 Dokker.copyTemplate = function(options) {
-  return new Promise(function(resolve, reject) {
-    var templatesDir = path.join(process.cwd(), 'templates');
-    return Dokker.mkdir(templatesDir)
-    .then(function() {
-      var oldStyle = path.join(__dirname, 'templates', 'styles.css');
-      var newStyle = path.join(process.cwd(), options.dir, 'styles.css');
-      fs.createReadStream(oldStyle).pipe(fs.createWriteStream(newStyle));
-      var oldLogo = path.join(__dirname, 'templates', 'logo.png');
-      var newLogo = path.join(process.cwd(), options.dir, 'logo.png');
-      fs.createReadStream(oldLogo).pipe(fs.createWriteStream(newLogo));
-      var oldApp = path.join(__dirname, 'templates', 'app.js');
-      var newApp = path.join(process.cwd(), options.dir, 'app.js');
-      fs.createReadStream(oldApp).pipe(fs.createWriteStream(newApp));
-      resolve();
+    return new Promise(function(resolve, reject) {
+        var templatesDir = path.join(process.cwd(), 'templates');
+        return Dokker.mkdir(templatesDir)
+            .then(function() {
+                var oldStyle = path.join(__dirname, 'templates', 'styles.css');
+                var newStyle = path.join(process.cwd(), options.dir, 'styles.css');
+                fs.createReadStream(oldStyle).pipe(fs.createWriteStream(newStyle));
+                var oldLogo = path.join(__dirname, 'templates', 'logo.png');
+                var newLogo = path.join(process.cwd(), options.dir, 'logo.png');
+                fs.createReadStream(oldLogo).pipe(fs.createWriteStream(newLogo));
+                var oldApp = path.join(__dirname, 'templates', 'app.js');
+                var newApp = path.join(process.cwd(), options.dir, 'app.js');
+                fs.createReadStream(oldApp).pipe(fs.createWriteStream(newApp));
+                resolve();
+            });
     });
-  });
 };
 
 /**
@@ -455,15 +457,15 @@ Dokker.copyTemplate = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Copies the .Dokker.json file to bootstrap any Dokker project.
-Dokker.init = function(){
-  return new Promise(function(resolve, reject) {
-    var oldDok = path.join(__dirname, '.dokker.json');
-    var newDok = path.join(process.cwd(), '.dokker.json');
-    fs.createReadStream(oldDok).pipe(fs.createWriteStream(newDok));
-    resolve();
-  });
+Dokker.init = function() {
+    return new Promise(function(resolve, reject) {
+        var oldDok = path.join(__dirname, '.dokker.json');
+        var newDok = path.join(process.cwd(), '.dokker.json');
+        fs.createReadStream(oldDok).pipe(fs.createWriteStream(newDok));
+        resolve();
+    });
 };
 
 /**
@@ -481,18 +483,18 @@ Dokker.init = function(){
  * .then(function(){
  *   // => resolved promise
  * });
-*/
+ */
 // Starts the Node.js/Express server to watch Dokker.js project
 // documentation.
 Dokker.watch = function(options) {
-  // replacing watch cmd with gulp exported from gulpfile
-  var gulpex = require(__dirname+'/gulpfile.js').gulpex;
-  return gulpex();
-  // return new Promise(function(resolve, reject){ 
-  //   exec('DIR='+ options.dir + ' node ' + options.dir + '/app.js', function(error, stdout, stderr){
-  //     if(error) return reject(stderr);
-  //   });
-  // });
+    // replacing watch cmd with gulp exported from gulpfile
+    var gulpex = require(__dirname + '/gulpfile.js').gulpex;
+    return gulpex();
+    // return new Promise(function(resolve, reject){ 
+    //   exec('DIR='+ options.dir + ' node ' + options.dir + '/app.js', function(error, stdout, stderr){
+    //     if(error) return reject(stderr);
+    //   });
+    // });
 };
 
 module.exports = Dokker;

--- a/dokker.js
+++ b/dokker.js
@@ -26,7 +26,7 @@ var Dokker = {};
  * @memberOf Dokker
  * @type string
  */
-Dokker.VERSION = '0.1.0';
+ Dokker.VERSION = '0.1.0';
 
 /**
  * Creates a HTML file that transcludes the HTML snippet that was created
@@ -58,7 +58,7 @@ Dokker.VERSION = '0.1.0';
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Transclude in a ejs template file the HTML snippet that was ultimately
 // created with docdown. Also tweak the HTML page a bit and finally
 // inject the README.md.
@@ -121,7 +121,7 @@ Dokker.injectTemplate = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Create a HTML site from any mocha tests find when executing mocha
 // --reporter doc terminal command.
 Dokker.createTests = function(options) {
@@ -163,7 +163,7 @@ Dokker.createTests = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Extract docs folder to separate git branch and finally push branch to
 // Github repository
 Dokker.ghPages = function(){
@@ -202,7 +202,7 @@ Dokker.ghPages = function(){
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Create an HTML file from any source code comments in the style of
 // [literate programming](https://de.wikipedia.org/wiki/Literate_programming)
 Dokker.literate = function (options) {
@@ -249,7 +249,7 @@ Dokker.literate = function (options) {
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Convert markdown from any source code comments with docdown module.
 Dokker.jsdocMarkdown = function (options) {
   return new Promise(function(resolve, reject) {
@@ -266,7 +266,7 @@ Dokker.jsdocMarkdown = function (options) {
       var markdown = docdown({
         'path': tmpFile,
         'url': options.github,
-        'toc': 'categories',
+        'toc': 'categories'
       });
       return write(options.markdown, markdown, 'utf8');
     }).then(function() {
@@ -298,7 +298,7 @@ Dokker.jsdocMarkdown = function (options) {
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Create an HTML file from any source code comments in the style of
 // [literate programming](https://de.wikipedia.org/wiki/Literate_programming)
 Dokker.jsdocHtml = function (options) {
@@ -375,7 +375,7 @@ Dokker.mkdir = function(dir) {
  *   // => object with absolute pathes to the directory from
  *   // which the command was executed
  * });
- */
+*/
 // Parses the options file, .Dokker.json, and sets the default parameters.
 Dokker.configure = function(options) {
   return new Promise(function(resolve, reject){
@@ -387,7 +387,7 @@ Dokker.configure = function(options) {
       data.mocha.template = (data.mocha.template) ? path.join(process.cwd(), data.mocha.template) : path.join(__dirname, 'templates/tests.ejs.html');
       data.mocha.path = path.join(process.cwd(), data.dir, data.mocha.path);
       // specifies mocha command in .dokker.json; e.g. mocha -u tdd -R spec
-      data.mocha.command = path.join(process.cwd(), data.dir, data.mocha.command);
+      // data.mocha.command = path.join(process.cwd(), data.dir, data.mocha.command);
       data.literate.dir = path.join(process.cwd(), data.dir, data.literate.dir);
       data.jsdoc.markdown = path.join(process.cwd(), data.dir, data.jsdoc.markdown);
       data.jsdoc.html = path.join(process.cwd(), data.dir, data.jsdoc.html);
@@ -420,7 +420,7 @@ Dokker.configure = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Copy starter template to bootstrap any Dokker project.
 Dokker.copyTemplate = function(options) {
   return new Promise(function(resolve, reject) {
@@ -455,7 +455,7 @@ Dokker.copyTemplate = function(options) {
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Copies the .Dokker.json file to bootstrap any Dokker project.
 Dokker.init = function(){
   return new Promise(function(resolve, reject) {
@@ -481,15 +481,18 @@ Dokker.init = function(){
  * .then(function(){
  *   // => resolved promise
  * });
- */
+*/
 // Starts the Node.js/Express server to watch Dokker.js project
 // documentation.
 Dokker.watch = function(options) {
-  return new Promise(function(resolve, reject){ 
-    exec('DIR='+ options.dir + ' node ' + options.dir + '/app.js', function(error, stdout, stderr){
-      if(error) return reject(stderr);
-    });
-  });
+  // replacing watch cmd with gulp exported from gulpfile
+  var gulpex = require(__dirname+'/gulpfile.js').gulpex;
+  return gulpex();
+  // return new Promise(function(resolve, reject){ 
+  //   exec('DIR='+ options.dir + ' node ' + options.dir + '/app.js', function(error, stdout, stderr){
+  //     if(error) return reject(stderr);
+  //   });
+  // });
 };
 
 module.exports = Dokker;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ gulp.task('watch', ['reload'], function() {
 })
 
 // gulp.task('build', exec.bind('some build command here'))
-gulp.task('build', exec.bind(wpath+'/node_modules/dokker/bin/dokker'))
+gulp.task('build', exec.bind((wpath+'/node_modules/dokker/bin/dokker').replace(/\s/, '\\ ')))
 // Reloading browserSync
 gulp.task('reload', ['build'], reload);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,74 @@
+// dependencies
+var browserSync = require('browser-sync').create();
+var cp = require('child_process');
+var gulp = require('gulp');
+var path = require('path');
+var q = require('q');
+
+// working path
+var wpath = path.join(process.cwd());
+
+// gulp entry point
+gulp.task('default', ['start']);
+gulp.task('start', ['build', 'reload', 'watch']);
+
+// watch for file changes in wpath
+gulp.task('watch', ['reload'], function() {
+    gulp.watch(wpath + '/*.js', ['build', 'reload'])
+})
+
+// gulp.task('build', exec.bind('some build command here'))
+gulp.task('build', exec.bind(wpath+'/node_modules/dokker/bin/dokker'))
+// Reloading browserSync
+gulp.task('reload', ['build'], reload);
+
+// reload browserSync
+function reload() {
+    var defer = q.defer();
+
+    if (browserSync.active) {
+        browserSync.reload();
+        defer.resolve();
+    } else
+    startServer().then(defer.resolve);
+
+    return defer.promise;
+}
+
+// start a browserSync server to index.html directly
+function startServer() {
+    var defer = q.defer();
+
+    var serverConfig = {
+        server: {
+            baseDir: wpath,
+            directory: true
+        },
+        startPath: 'docs/index.html',
+        // browser: "google chrome",
+        logPrefix: 'SERVER'
+    };
+    browserSync.init(serverConfig, defer.resolve);
+
+    return defer.promise;
+}
+
+// terminal exec task with promise: use as exec.bind(<command>)
+function exec() {
+    var defer = q.defer();
+    cp.exec(this, function(err, stdout, stderr) {
+        if (err) console.log('exec err: '+ err);
+        console.log(stdout);
+        defer.resolve(err)
+    })
+    return defer.promise;
+}
+
+// // export for normal render run
+function gulpex(options){
+	// set process.env.DIR then run task
+	// return exec.bind('DIR='+ options.dir)()
+	// .done(gulp.start('default'))
+	return gulp.start('default')
+}
+exports.gulpex = gulpex;

--- a/package.json
+++ b/package.json
@@ -23,14 +23,17 @@
   },
   "homepage": "https://dokkerjs.com",
   "dependencies": {
+    "browser-sync": "^2.7.12",
     "cheerio": "^0.19.0",
     "docco": "^0.7.0",
     "docdown": "^0.2.0",
     "ejs": "^2.3.1",
+    "gulp": "^3.9.0",
     "lodash": "^3.9.3",
     "marked": "^0.3.3",
     "nodemon": "^1.3.7",
-    "promise": "^7.0.3"
+    "promise": "^7.0.3",
+    "q": "^1.4.1"
   },
   "devDependencies": {
     "express": "^4.13.0",

--- a/templates/index.ejs.html
+++ b/templates/index.ejs.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="author" content="Dokker.js">
+  <meta name="description" content="This API documentation is built with Dokker.js at dokkerjs.com">
   <title><%= title %></title>
   <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="styles.css" media="all">

--- a/templates/tests.ejs.html
+++ b/templates/tests.ejs.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="author" content="Dokker.js">
+    <meta name="description" content="This API documentation is built with Dokker.js at dokkerjs.com">
     <title>Dokker.js</title>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.3/jquery.min.js"></script>
     <style>


### PR DESCRIPTION
Hello @georgschlenkhoff I was having lunch and thought why not do it now?

1) I added `browserSync` and `Gulp` for the worry-free browser live-preview, i.e. without having to install anything else. Only supplanted the original `watch` method at line 48 of `dokker.js` with the gulp task, which is written all in the gulpfile.js.
Tested it and it ran like a charm. Just do the `./node_modules/dokker/bin/watch` as usual. You can save your `.js` file and it will rebuild and reload automatically.
You might wish to update your README and drop the need to install Live Preview. Maybe the new description would be "just do `./node_modules/dokker/bin/watch` and magic will happen.

2) Fixed a build-breaking bug at line 390 which the `mocha.command`. It's not needed and the build system doesn't know what to do with it.

So basically we are at the next version of Dokker, with an awesome live-preview!
